### PR TITLE
Fix about me nav section

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,7 +18,7 @@
       <p class="header__title">Italo Canturil</p>
       <nav class="header__nav">
         <p class="nav__menu nav__portfolio">Portfolio</p>
-        <a href="src/about.html" class="nav__menu nav__sobre">Sobre</a>
+        <p class="nav__menu nav__sobre">Sobre</p>
 
         <a href="#" class="nav__lang active" language="portugues">BR</a>
         <a href="#" class="nav__lang" language="english">EN</a>


### PR DESCRIPTION
Right now if you click on "About me" or "Sobre" it will trigger a 404 error page not found.

Replaced this:
`<a href="src/about.html" class="nav__menu nav__sobre">Sobre</a>
`
With this:
`<p class="nav__menu nav__sobre">Sobre</p>`